### PR TITLE
Bug/insufficient data type for search results

### DIFF
--- a/db/migrate/20201026104633_change_count_hits_data_type_to_big_int_on_search_results.rb
+++ b/db/migrate/20201026104633_change_count_hits_data_type_to_big_int_on_search_results.rb
@@ -1,0 +1,5 @@
+class ChangeCountHitsDataTypeToBigIntOnSearchResults < ActiveRecord::Migration[6.0]
+  def change
+    change_column :search_results, :count_hits, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_172551) do
+ActiveRecord::Schema.define(version: 2020_10_26_104633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2020_10_21_172551) do
     t.bigint "report_id", null: false
     t.integer "count_adwords_advertisers"
     t.integer "count_links"
-    t.integer "count_hits"
+    t.bigint "count_hits"
     t.decimal "elapsed_time", precision: 5, scale: 2
     t.text "html"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/cassettes/SearchResult_Create/successfully_creates_search_results.yml
+++ b/spec/cassettes/SearchResult_Create/successfully_creates_search_results.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://chromedriver.storage.googleapis.com/LATEST_RELEASE_86.0.4240
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - chromedriver.storage.googleapis.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - ABg5-UwHEbG_wNU88k_c732WK7kjjwtdjBwkkaoxPxBYno6j6tUNVV77n_GOzVkUVFK9NL4_BPW78sZChwsQcBBkEtX-2nn5OQ
+      Expires:
+      - Mon, 26 Oct 2020 11:28:37 GMT
+      Date:
+      - Mon, 26 Oct 2020 10:28:37 GMT
+      Last-Modified:
+      - Thu, 03 Sep 2020 19:26:48 GMT
+      Etag:
+      - '"f479d6ade97303eb0aacc218af38d679"'
+      X-Goog-Generation:
+      - '1599161208989009'
+      X-Goog-Metageneration:
+      - '1'
+      X-Goog-Stored-Content-Encoding:
+      - identity
+      X-Goog-Stored-Content-Length:
+      - '12'
+      Content-Type:
+      - text/plain
+      X-Goog-Hash:
+      - crc32c=8IbTGA==
+      - md5=9HnWrelzA+sKrMIYrzjWeQ==
+      X-Goog-Storage-Class:
+      - STANDARD
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '12'
+      Server:
+      - UploadServer
+      Cache-Control:
+      - public, max-age=3600
+      Age:
+      - '0'
+      Alt-Svc:
+      - h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443";
+        ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
+        ma=2592000; v="46,43"
+    body:
+      encoding: UTF-8
+      string: 86.0.4240.22
+  recorded_at: Mon, 26 Oct 2020 10:28:37 GMT
+recorded_with: VCR 6.0.0

--- a/spec/models/search_result_spec.rb
+++ b/spec/models/search_result_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe SearchResult, type: :model do
   it 'is valid' do
-    expect(Fabricate.build(:search_result)).to be_valid
+    exceeding_four_bytes = 2_147_483_647 + 1
+    record = Fabricate.build(:search_result, count_hits: exceeding_four_bytes)
+    expect(record).to be_valid
+    expect { record.save! }.not_to raise_error
   end
 
   it 'is invalid' do


### PR DESCRIPTION
https://github.com/nimblehq/git-template/issues/??

## What happened 👀

In order to store a count of total search results in SearchResult#count_hits, we need a data type that can store incoming numbers larger than 4 bytes. Use bigint (8 bytes) instead.
 
## Insight 📝

Expand the unit test for the SearchResult model, verify it can store numbers exceeding 4 bytes.
 
## Proof Of Work 📹

N/A
